### PR TITLE
fix: update lastReadDate when checking the interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-writer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "build": "tsc",
     "test": "echo \"No tests to run.\""

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,7 @@ watchCommand
 program
   .name('ghost-writer')
   .description('CLI to manage posts on a Ghost blog')
-  .version('1.0.0')
+  .version('1.0.2')
   .addCommand(publishCommand)
   .addCommand(deleteCommand)
   .addCommand(findCommand)


### PR DESCRIPTION
### Link To Issue:
#4 
### Description of Issue:
The date it was checking for if it should publish a post was never updated when a post was published.
### Solution:
Repull and update the most recent post date on each interval.
### Notes:
closes #4 